### PR TITLE
Change for alert security from github spring-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<springframework.version>4.3.0.RELEASE</springframework.version>
+		<springframework.version>4.3.25.RELEASE</springframework.version>
 		<hibernate.version>4.3.6.Final</hibernate.version>
 		<jackson.library>2.7.5</jackson.library>
 		<h2.version>1.4.199</h2.version>


### PR DESCRIPTION
Fix security alert because the library "org.springframework:spring-core"  was minor then 4.3.17 version and there's a vulnerability that library.